### PR TITLE
Add trace id to dwb import error

### DIFF
--- a/src/dataworkbench/gateway.py
+++ b/src/dataworkbench/gateway.py
@@ -154,6 +154,6 @@ class Gateway:
             )
             logger.error(f"Error creating data catalog entry: {e}")
             return {
-                "error ID": trace_id,
                 "error": "Failed to create data catalog entry.",
+                "correlation_id": trace_id,
             }

--- a/src/dataworkbench/gateway.py
+++ b/src/dataworkbench/gateway.py
@@ -1,6 +1,7 @@
 from typing import Any
 import requests
 from uuid import UUID
+import json
 
 from dataworkbench.utils import get_secret
 from dataworkbench.auth import TokenManager
@@ -8,6 +9,11 @@ from dataworkbench.log import setup_logger
 
 # Configure logging
 logger = setup_logger(__name__)
+
+
+def _get_trace_id_from_response(response: requests.Response) -> str | None:
+    response_dict = json.loads(response.text)
+    return response_dict.get("traceId")
 
 
 class Gateway:
@@ -135,7 +141,19 @@ class Gateway:
         logger.info(f"Sending request to import dataset: {dataset_name}")
 
         try:
-            return self.__send_request(url, payload)
+            response = self.__send_request(url, payload)
+            logger.info(
+                f"Successfully imported dataset {dataset_name} to Data Workbench"
+            )
+            return response
         except requests.exceptions.RequestException as e:
+            trace_id = (
+                _get_trace_id_from_response(e.response)
+                if e.response is not None
+                else None
+            )
             logger.error(f"Error creating data catalog entry: {e}")
-            return {"error": f"Failed to create data catalog entry: {str(e)}"}
+            return {
+                "Error ID": trace_id,
+                "error": "Failed to create data catalog entry.",
+            }

--- a/src/dataworkbench/gateway.py
+++ b/src/dataworkbench/gateway.py
@@ -155,5 +155,5 @@ class Gateway:
             logger.error(f"Error creating data catalog entry: {e}")
             return {
                 "error": "Failed to create data catalog entry.",
-                "correlation_id": trace_id,
+                "correlation-id": trace_id,
             }

--- a/src/dataworkbench/gateway.py
+++ b/src/dataworkbench/gateway.py
@@ -154,6 +154,6 @@ class Gateway:
             )
             logger.error(f"Error creating data catalog entry: {e}")
             return {
-                "Error ID": trace_id,
+                "error ID": trace_id,
                 "error": "Failed to create data catalog entry.",
             }

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -49,5 +49,5 @@ def test_import_dataset_failure(mock_gateway, mock_post):
 
     result = mock_gateway.import_dataset("dataset_name", "dataset_description", "schema_id", {"tag": "value"}, "folder_id")
 
-    assert result == {"error": "Failed to create data catalog entry.", "correlation_id": response_body["traceId"]}
+    assert result == {"error": "Failed to create data catalog entry.", "correlation-id": response_body["traceId"]}
     mock_post.assert_called_once()

--- a/tests/test_gateway.py
+++ b/tests/test_gateway.py
@@ -49,5 +49,5 @@ def test_import_dataset_failure(mock_gateway, mock_post):
 
     result = mock_gateway.import_dataset("dataset_name", "dataset_description", "schema_id", {"tag": "value"}, "folder_id")
 
-    assert result == {"error ID": response_body["traceId"], "error": "Failed to create data catalog entry."}
+    assert result == {"error": "Failed to create data catalog entry.", "correlation_id": response_body["traceId"]}
     mock_post.assert_called_once()


### PR DESCRIPTION
If the import to data workbench fails, it should return the trace id for easy access to logs